### PR TITLE
DRAFT: Pkg opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Git log, git status and git changed source for [ido.nvim](https://github.com/ido
 
 Introduces the following ido packages:
 
-| PKG_NAME   | default behavior |
-|----------|---------|
-| git-diff | returns the files changed since HEAD |
+| PKG_NAME   | purpose                              | default command       |
+|------------|--------------------------------------|-----------------------|
+| git-diff   | returns the files changed since HEAD | `git diff --name-only`|
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [WIP] ido-git
+# [WIP] Git
 
 Git log, git status and git changed source for [ido.nvim](https://github.com/ido-nvim/core)
 
@@ -30,7 +30,7 @@ Where `PKG_NAME` is the package you wish to run.
 
 The `ido-pkg/git.lua` module is loaded by default. This behavior can be overridden by setting `g:ido_pkg_git_loaded` to 1.
 
-`ido-git` provides the end-user the option to specify the git command used per source.
+You have the option to specify the git command used per source.
 
 For example, in order to overwrite the command used by the `git_diff` source:
 
@@ -54,8 +54,10 @@ require("ido").pkg.run('git-diff', {
 
 ### Default Bindings
 
-`ido-git` comes with the following default bindings. These can be overwritten using the [bind option](https://github.com/ido-nvim/core/blob/main/wiki/packages.md#pkgbindname-opts)
+The following default bindings are provided:
 
 | binding    | source |
 |----------|---------|
 | <leader>gd | git_diff |
+
+These can be overwritten using the [bind option](https://github.com/ido-nvim/core/blob/main/wiki/packages.md#pkgbindname-opts)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `ido-pkg/git.lua` module is loaded by default. This behavior can be overridd
 
 `ido-git` provides the end-user the option to specify the git command used per source.
 
-For example, in order to overwrite the command used by the `git_diff` source, to return the changed files since `master`:
+For example, in order to overwrite the command used by the `git_diff` source:
 
 ```lua
 require("ido").pkg.setup('git-diff', {
@@ -40,6 +40,15 @@ require("ido").pkg.setup('git-diff', {
     -- overwrite the DIFF_COMMAND to return the changed files compared to master branch
     command = 'git diff master --name-only'
   }
+})
+```
+
+Or to overwrite it just for a single run:
+
+```lua
+require("ido").pkg.run('git-diff', {
+  -- overwrite the DIFF_COMMAND to return the changed files compared to master branch
+  command = 'git diff master --name-only'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # [WIP] ido-git
 
-Several sources for varying git commands
+Git log, git status and git changed source for [ido.nvim](https://github.com/ido-nvim/core)
+
+Introduces the following ido packages:
+
+| PKG_NAME   | default behavior |
+|----------|---------|
+| git-diff | returns the files changed since HEAD |
 
 ### Installation
 
@@ -12,36 +18,34 @@ For example using packer.nvim:
 use { 'ido-nvim/ido-git', configure = function() require 'ido-pkg/git_diff' end }
 ```
 
-### Configuration
+### Run
 
-The `ido-pkg/git.lua` module is not loaded by default.
-This is done to provide maximum extensibility. As such one is required to `require` the module
-somewhere in your vim configuration.
-
-As a result the command used to populate the items for each source can be customized by overwriting
-the corresponding constant on the module.
-
-For example, in order to overwrite the command used by the `git_diff` source:
-
-```lua
--- register the git package with IDO
-local ido_git = require('ido-pkg/git')
-
--- overwrite the DIFF_COMMAND to return the changed files compared to master branch
-ido_git.DIFF_COMMAND = 'git diff master --name-only'
+```vim
+:lua require("ido").pkg.run(PKG_NAME, PKG_OPTS)
 ```
 
-### Sources
+Where `PKG_NAME` is the package you wish to run.
 
-ido-git comes with several default sources:
+### Configuration
 
+The `ido-pkg/git.lua` module is loaded by default. This behavior can be overridden by setting `g:ido_pkg_git_loaded` to 1.
 
-| source   | purpose |
-|----------|---------|
-| git-diff | returns the files changed since HEAD |
+`ido-git` provides the end-user the option to specify the git command used per source.
+
+For example, in order to overwrite the command used by the `git_diff` source, to return the changed files since `master`:
+
+```lua
+require("ido").pkg.setup('git-diff', {
+  pkg_opts = {
+    -- overwrite the DIFF_COMMAND to return the changed files compared to master branch
+    command = 'git diff master --name-only'
+  }
+})
+```
 
 ### Default Bindings
 
+`ido-git` comes with the following default bindings. These can be overwritten using the [bind option](https://github.com/ido-nvim/core/blob/main/wiki/packages.md#pkgbindname-opts)
 
 | binding    | source |
 |----------|---------|

--- a/lua/ido-pkg/git.lua
+++ b/lua/ido-pkg/git.lua
@@ -6,7 +6,7 @@ local function exists(path)
   return io.open(path, "r") and true or false
 end
 
-local function check_git()
+local function ensure_git()
   -- Check if the current directory is a git repo
    if os.execute("git rev-parse --is-inside-work-tree 2>/dev/null") ~= 0 then
       vim.cmd("echohl ErrorMsg | echo 'Not a git repository!' | echohl Normal")
@@ -14,16 +14,15 @@ local function check_git()
    end
 end
 
-local module = {}
 
 -- GIT DIFF {{{
-module.DIFF_COMMAND = 'git diff --name-only'
+local DIFF_COMMAND = 'git diff --name-only'
 
-module.diff = function()
-  check_git()
+local function git_diff(pkg_opts)
+  ensure_git()
 
   local file = pkg.start({
-    items = vim.fn.systemlist(module.DIFF_COMMAND),
+    items = vim.fn.systemlist(pkg_opts.command),
     prompt = "Git diff: ",
   })
 
@@ -36,7 +35,10 @@ end
 
 -- Setup the package
 pkg.new("git_diff", {
-   main = module.diff,
+   main = git_diff,
+   pkg_opts = {
+     command = DIFF_COMMAND
+   },
    bind = {
       -- Bind it to <Leader>gf
       key = "<Leader>gd",

--- a/plugin/git.vim
+++ b/plugin/git.vim
@@ -1,0 +1,5 @@
+if exists("g:ido_pkg_git_loaded") | finish | endif
+
+lua require("ido-pkg/git")
+
+let g:ido_pkg_git_loaded = 1


### PR DESCRIPTION
This uses the experimental `pkg_opts` PR in the ido core branch.

The purpose of this PR is to provide a clear example of the benefits and flexibility the new `pkg_opts` option would provide when included in the ido package API.